### PR TITLE
Add support for findall and product_list

### DIFF
--- a/le_input.pl
+++ b/le_input.pl
@@ -730,6 +730,11 @@ condition(FinalExpression, _, Map1, MapN) -->
     newline, spaces(Ind2), where_, conditions(Ind2, Map3, Map4, Goals),
     modifiers(setof(Term,Goals,Set), Map4, MapN, FinalExpression).
 
+condition(FinalExpression, _, Map1, MapN) --> 
+    variable([is], Set, Map1, Map2), is_the_bag_of_all_, term_([], Term, Map2, Map3), !, % moved where to the following line
+    newline, spaces(Ind2), where_, conditions(Ind2, Map3, Map4, Goals),
+    modifiers(findall(Term,Goals,Set), Map4, MapN, FinalExpression).
+
 % for every a party is a party in the event, it is the case that:
 condition(FinalExpression, _, Map1, MapN) -->  
     for_all_cases_in_which_, newline, !, 
@@ -900,6 +905,8 @@ is_a_set_of_ --> [is], spaces(_), [a], spaces(_), [set], spaces(_), [of], spaces
 is_a_set_of_ --> [es], spaces(_), [un],  spaces(_), [conjunto],  spaces(_), [de], spaces(_). % spanish
 is_a_set_of_ --> [est], spaces(_), [un],  spaces(_), [ensemble],  spaces(_), [de],  spaces(_). % french
 is_a_set_of_ --> [est], spaces(_), [un],  spaces(_), [ensemble],  spaces(_), [de],  spaces(_). % italian
+
+is_the_bag_of_all_ --> [is], spaces(_), [the], spaces(_), [set], spaces(_), [of], spaces(_), [all], spaces(_).
 
 where_ --> [where], spaces(_). 
 where_ --> [en], spaces(_), [donde], spaces(_). % spanish
@@ -2149,6 +2156,7 @@ dictionary(Predicate, VariablesNames, Template) :- % dict(Predicate, VariablesNa
 predef_dict([length, List, Length], [member-object, list-list], [the, length, of, List, is, Length]).
 predef_dict([bagof, Thing, Condition, Bag], [bag-thing, thing-thing, condition-condition], [Bag, is, a, bag, of, Thing, such, that, Condition]).
 predef_dict([has_as_head_before, A, B, C], [list-list, symbol-term, rest_of_list-list], [A, has, B, as, head, before, C]).
+predef_dict([product_list, Number, List], [thing-thing, list-list], [Number, is, the, prod, of, List]).
 predef_dict([append, A, B, C],[first_list-list, second_list-list, third_list-list], [appending, A, then, B, gives, C]).
 predef_dict([reverse, A, B], [list-list, other_list-list], [A, is, the, reverse, of, B]).
 predef_dict([same_date, T1, T2], [time_1-time, time_2-time], [T1, is, the, same, date, as, T2]). % see reasoner.pl before/2

--- a/reasoner.pl
+++ b/reasoner.pl
@@ -17,7 +17,7 @@ limitations under the License.
 :- module(reasoner,[query/4, query_with_facts/5, query_once_with_facts/5, explanation_node_type/2, render_questions/2,
     run_examples/0, run_examples/1, myClause2/9, myClause/4, taxlogWrapper/10, niceModule/2, refToOrigin/2,
     isafter/2, is_not_before/2, isbefore/2, immediately_before/2, same_date/2, subtract_days/3, this_year/1, uk_tax_year/4, in/2,
-    isExpressionFunctor/1, set_time_of_day/3, start_of_day/2, end_of_day/2, is_days_after/3, is_1_day_after/2, unparse_time/2
+    isExpressionFunctor/1, set_time_of_day/3, start_of_day/2, end_of_day/2, is_days_after/3, is_1_day_after/2, unparse_time/2, product_list/2
     ]).
 
 /** <module> Tax-KB reasoner and utils
@@ -728,6 +728,11 @@ uk_tax_year(Start,StartYear,Start,End) :- must_be(integer,StartYear),
 in(X,List) :- must_be(list,List), member(X,List).
 
 has_as_head_before([Head|Rest],Head,Rest). 
+
+product_list(1, []).
+product_list(X, [H | T]) :-
+  product_list(Y, T),
+  X is H * Y.
 
 :- if(current_module(swish)). %%%%% On SWISH:
 


### PR DESCRIPTION
We now support the following syntax:
```
a Bag is the bag of all x
where condition
```
as well as
```
a number is the prod of a list
```